### PR TITLE
Add type-inference to resolver

### DIFF
--- a/Modules/Sources/DI/DIContainer.swift
+++ b/Modules/Sources/DI/DIContainer.swift
@@ -29,4 +29,8 @@ public final class DIContainer: DIResolver {
         }
         return instance
     }
+
+    public func callAsFunction<T>() -> T {
+        return resolve(T.self)
+    }
 }

--- a/Modules/Sources/DI/DIResolver.swift
+++ b/Modules/Sources/DI/DIResolver.swift
@@ -2,4 +2,5 @@ import Foundation
 
 public protocol DIResolver {
     func resolve<T: Any>(_ type: T.Type) -> T
+    func callAsFunction<T: Any>() -> T
 }

--- a/Modules/Sources/Feature/Impl/FeatureAssembly.swift
+++ b/Modules/Sources/Feature/Impl/FeatureAssembly.swift
@@ -18,8 +18,8 @@ public final class FeatureAssembly: DIAssembly {
         container.register(FeatureRepository.self) { r in
             let loggerFactory = r.resolve(LoggerCreating.self)
             return FeatureRepositoryImpl(
-                stringStore: r.resolve((any StringStore).self),
-                dateStore: r.resolve((any DateStore).self),
+                stringStore: r(),
+                dateStore: r(),
                 logger: loggerFactory.make(name: "FeatureRepository")
             )
         }


### PR DESCRIPTION
An idea that I used in [SwinjectAutoregistration](https://github.com/Swinject/SwinjectAutoregistration) was to use the type-inference to get the type of the resolved object. We used custom operator there but I think [callAsFunction](https://www.donnywals.com/how-and-when-to-use-callasfunction-in-swift-5-2/) is better suited for this.

It saves a lot of writing, what do you think? 